### PR TITLE
Update the endpoint for fleet kickscooter search

### DIFF
--- a/docs/kickscooter_endpoint.md
+++ b/docs/kickscooter_endpoint.md
@@ -127,7 +127,7 @@ curl --request GET \
 
 ### Search Kick Scooter
 
-`GET /v2/fleet/kickscooter?serialNumber=:kickscooterSerialNumber`
+`GET /v2/fleet/kickscooter/search?serialNumber=:kickscooterSerialNumber`
 
 ##### Example response
 


### PR DESCRIPTION
Seems the `/search` part of the URL was missing