### PR TITLE
[API] update notes for POST request

### DIFF
--- a/docs/kickscooter_endpoint.md
+++ b/docs/kickscooter_endpoint.md
@@ -8,7 +8,7 @@
 
 | Key | Type | Required | Notes                                                                                                 |
 | --- | --- |----------|-------------------------------------------------------------------------------------------------------|
-| coverStartsAt | iso-8601 string | No       |                                                                                                       |
+| coverStartsAt | iso-8601 string | No       | If not provided in the POST message the vehicle will be created using the current date and time.                                                                     |
 | city | string | No       |                                                                                                       |
 | coverEndsAt | iso-8601 string | No       |                                                                                                       |
 | kickscooter.serialNumber | string | Yes      |                                                                                                       |


### PR DESCRIPTION
Add the following msg in Notes section for coverStartsAt key

If not provided in the POST message the vehicle will be created using the current date and time.

https://zegons.atlassian.net/browse/INTNL-332